### PR TITLE
Update PlugPagService Wrapper to version 1.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,15 +27,15 @@ android {
 }
 
 dependencies {
-    implementation 'br.com.uol.pagseguro.plugpagservice.wrapper:wrapper:1.3.3'
+    implementation 'br.com.uol.pagseguro.plugpagservice.wrapper:wrapper:1.6.0'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.hannesdorfmann.mosby:mvp:2.0.1'
     implementation 'com.google.dagger:dagger:2.15'
     annotationProcessor "com.google.dagger:dagger-compiler:2.15"
-    implementation 'com.jakewharton:butterknife:8.8.1'
+    annotationProcessor 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.16'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 07 14:44:13 BRST 2019
+#Sat Mar 21 20:53:52 BRT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
This commit intends to update the PlugPagService Wrapper library to its latest version 1.6.0 in order to use the new API methods and keep it up to date.